### PR TITLE
Fix Scrutinizer Node runtime for app-community

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -5,7 +5,7 @@ build:
   nodes:
     analysis:
       environment:
-        node: v16
+        node: v20
       project_setup:
         override: true
       tests:


### PR DESCRIPTION
## Summary
- align the Scrutinizer Node runtime with the project's declared Node major version
- avoid the `structuredClone is not defined` failure during `eslint-run .`
- track the operational incident in issue #143

## Context
The Scrutinizer alert from May 9, 2026 showed `eslint-run .` failing with `structuredClone is not defined`. In this repository, `.scrutinizer.yml` was still using `node: v16`, while `package.json` already declares `node: 20`.

## Change
- update `.scrutinizer.yml` to use `node: v20` for the analysis node

## Validation
- inspected the failing Scrutinizer email from Gmail trash
- confirmed the runtime mismatch between `.scrutinizer.yml` and `package.json`
- applied the configuration change on this branch

Closes #143